### PR TITLE
Added set max connection to limit database connection

### DIFF
--- a/testapp.go
+++ b/testapp.go
@@ -38,6 +38,9 @@ func NewTestApp(appName string, controllerRouteProvider func(*App) []RouteSpecif
 		panic(err)
 	}
 
+	db.DB().SetMaxOpenConns(1)
+	db.Exec("PRAGMA journal_mode=WAL;")
+
 	db.LogMode(verbose)
 
 	logger := zerolog.New(os.Stdout)


### PR DESCRIPTION
Added setMaxConnection in test app. sqlite is a light weight database and might not support multiple connection when doing go routine test cases