### PR TITLE
Isla 1935 defect scope issue

### DIFF
--- a/security/Token.go
+++ b/security/Token.go
@@ -47,11 +47,12 @@ func (token *JwtToken) isValidForScope(allowedScopes []string) bool {
 	}
 
 	if len(nonPermissiveTokenScopes) > 0 && len(allowedScopes) > 0 {
+		fmt.Println("Negative scopes")
 		if isScopePresent(nonPermissiveTokenScopes, allowedScopes) {
 			return false
 		}
 	}
-
+	fmt.Println("Positive scopes")
 	return isScopePresent(permissiveTokenScopes, allowedScopes)
 }
 

--- a/security/Token.go
+++ b/security/Token.go
@@ -1,6 +1,7 @@
 package security
 
 import (
+	"fmt"
 	"strings"
 
 	jwt "github.com/dgrijalva/jwt-go"
@@ -55,6 +56,8 @@ func (token *JwtToken) isValidForScope(allowedScopes []string) bool {
 }
 
 func isScopePresent(scopes []string, scopeToCheck []string) bool {
+	fmt.Println("scopes --> ", scopes)
+	fmt.Println("scopeToCheck --> ", scopeToCheck)
 	if ok, _ := inArray("*", scopes); ok {
 		return true
 	}
@@ -63,6 +66,7 @@ func isScopePresent(scopes []string, scopeToCheck []string) bool {
 		if ok, _ := inArray(allowedScope, scopes); !ok {
 			scopeParts := strings.Split(allowedScope, ":")
 			if ok, _ := inArray(scopeParts[0]+":*", scopes); !ok {
+				fmt.Println("for loop scopeParts --> ", scopeParts)
 				if ok, _ := inArray("*:"+scopeParts[1], scopes); !ok {
 					allScopesMatched = false
 				}

--- a/security/Token.go
+++ b/security/Token.go
@@ -1,7 +1,6 @@
 package security
 
 import (
-	"fmt"
 	"strings"
 
 	jwt "github.com/dgrijalva/jwt-go"
@@ -47,18 +46,14 @@ func (token *JwtToken) isValidForScope(allowedScopes []string) bool {
 	}
 
 	if len(nonPermissiveTokenScopes) > 0 && len(allowedScopes) > 0 {
-		fmt.Println("Negative scopes")
 		if isScopePresent(nonPermissiveTokenScopes, allowedScopes) {
 			return false
 		}
 	}
-	fmt.Println("Positive scopes")
 	return isScopePresent(permissiveTokenScopes, allowedScopes)
 }
 
 func isScopePresent(scopes []string, scopeToCheck []string) bool {
-	fmt.Println("scopes --> ", scopes)
-	fmt.Println("scopeToCheck --> ", scopeToCheck)
 	if ok, _ := inArray("*", scopes); ok {
 		return true
 	}
@@ -66,6 +61,7 @@ func isScopePresent(scopes []string, scopeToCheck []string) bool {
 	for _, allowedScope := range scopeToCheck {
 		if ok, _ := inArray(allowedScope, scopes); !ok {
 			scopeParts := strings.Split(allowedScope, ":")
+			// If the api scope only has 1 value with no separator, e.g []string{"*"}, then we need to check if both scopes are same
 			if len(scopeParts) == 1 {
 				if ok, _ := inArray(scopeParts[0], scopes); !ok {
 					allScopesMatched = false
@@ -73,7 +69,6 @@ func isScopePresent(scopes []string, scopeToCheck []string) bool {
 				continue
 			}
 			if ok, _ := inArray(scopeParts[0]+":*", scopes); !ok {
-				fmt.Println("for loop scopeParts --> ", scopeParts)
 				if ok, _ := inArray("*:"+scopeParts[1], scopes); !ok {
 					allScopesMatched = false
 				}

--- a/security/Token.go
+++ b/security/Token.go
@@ -66,6 +66,12 @@ func isScopePresent(scopes []string, scopeToCheck []string) bool {
 	for _, allowedScope := range scopeToCheck {
 		if ok, _ := inArray(allowedScope, scopes); !ok {
 			scopeParts := strings.Split(allowedScope, ":")
+			if len(scopeParts) == 1 {
+				if ok, _ := inArray(scopeParts[0], scopes); !ok {
+					allScopesMatched = false
+				}
+				continue
+			}
 			if ok, _ := inArray(scopeParts[0]+":*", scopes); !ok {
 				fmt.Println("for loop scopeParts --> ", scopeParts)
 				if ok, _ := inArray("*:"+scopeParts[1], scopes); !ok {

--- a/security/Token_test.go
+++ b/security/Token_test.go
@@ -20,6 +20,9 @@ var scopeCombinations = []struct {
 	{[]string{"-user:read", "*"}, []string{"user:read", "user:write"}, true},
 	{[]string{"user:read", "*"}, []string{"user:read", "user:write"}, true},
 	{[]string{"user:read", "user:write", "user:delete"}, []string{"user:read", "user:write"}, true},
+	{[]string{"*"}, []string{"*"}, true},
+	{[]string{"user:read"}, []string{"*"}, false},
+	{[]string{"user:read", "*"}, []string{"*"}, true},
 }
 
 func TestScopes(t *testing.T) {


### PR DESCRIPTION
When the api scope has only 1 value and no separator, the scope check crashes as it get an array of only length 1. Added an additional check for scope length and perform a direct compare